### PR TITLE
Export KUBE_CONFIG_PATH used by Kubernetes Terraform provider

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -71,6 +71,7 @@ export async function run() {
       // export variable
       core.exportVariable('KUBECONFIG', kubeconfigPath)
       core.debug('KUBECONFIG environment variable set')
+      core.exportVariable('KUBE_CONFIG_PATH', kubeconfigPath)
 
       if (useKubeLogin) {
          const kubeloginCmd = ['convert-kubeconfig', '-l', 'azurecli']


### PR DESCRIPTION
The Kubernetes Terraform provider uses KUBE_CONFIG_PATH environment variable. Having both environment variables exported simplifies deployments overall.